### PR TITLE
Add grid and testing wall plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ opt-level = 3
 [dependencies]
 bevy = { version = "0.11.0", features = ["dynamic_linking"] }
 bevy_hanabi = { version = "0.7", default-features = false, features = ["2d"] }
+rand = "0.8"
+pathfinding = "4.3"
+futures-lite = "1.13"

--- a/src/game/grid.rs
+++ b/src/game/grid.rs
@@ -1,0 +1,325 @@
+use std::{
+    collections::HashSet,
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
+
+use bevy::{
+    prelude::*,
+    tasks::{AsyncComputeTaskPool, Task},
+};
+use futures_lite::future;
+use pathfinding::undirected::connected_components;
+use rand::{seq::IteratorRandom, Rng};
+
+// TODO Make this a generic on the plugin or otherwise configurable
+pub const GRID_SIZE: usize = 200;
+
+#[derive(Resource)]
+pub struct Grid<T> {
+    pub entities: [[Option<Entity>; GRID_SIZE]; GRID_SIZE],
+    _marker: PhantomData<T>,
+}
+
+#[derive(Resource)]
+pub struct ConnectedComponents<T> {
+    pub components: Vec<HashSet<GridLocation>>,
+    _marker: PhantomData<T>,
+}
+
+#[derive(Component, Eq, PartialEq, Hash, Clone, Debug, Deref, DerefMut)]
+pub struct GridLocation(pub IVec2);
+
+#[derive(Component)]
+pub struct LockToGrid;
+
+#[derive(Event)]
+pub struct DirtyGridEvent<T>(pub GridLocation, PhantomData<T>);
+
+#[derive(Default)]
+pub struct GridPlugin<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Component> Plugin for GridPlugin<T> {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<Grid<T>>()
+            .init_resource::<ConnectedComponents<T>>()
+            .add_systems(
+                Update,
+                (lock_to_grid::<T>, update_connected_components::<T>),
+            )
+            .add_event::<DirtyGridEvent<T>>()
+            // TODO move_on_grid / GridLocation change detection
+            .add_systems(Startup, first_dirty_event::<T>)
+            .add_systems(
+                PreUpdate,
+                (
+                    add_to_grid::<T>,
+                    remove_from_grid::<T>,
+                    resolve_connected_components::<T>,
+                ),
+            );
+    }
+}
+
+// Could change detect
+fn lock_to_grid<T: Component>(
+    grid: Res<Grid<T>>,
+    mut positions: Query<&mut Transform, (With<LockToGrid>, With<T>)>,
+) {
+    for (entity, location) in grid.iter() {
+        if let Ok(mut position) = positions.get_mut(entity) {
+            position.translation.x = location.x as f32;
+            position.translation.y = location.y as f32;
+        }
+    }
+}
+
+// Forces some sane initializations of connected components
+fn first_dirty_event<T: Component>(mut dirty: EventWriter<DirtyGridEvent<T>>) {
+    dirty.send(DirtyGridEvent::<T>(GridLocation::new(0, 0), PhantomData));
+}
+
+#[derive(Component)]
+struct ConnectedTask<T> {
+    task: Task<ConnectedComponents<T>>,
+}
+
+fn resolve_connected_components<T: Component>(
+    mut commands: Commands,
+    mut connected: ResMut<ConnectedComponents<T>>,
+    // Should maybe be a resource?
+    mut tasks: Query<(Entity, &mut ConnectedTask<T>)>,
+) {
+    for (task_entity, mut task) in &mut tasks {
+        if let Some(result) = future::block_on(future::poll_once(&mut task.task)) {
+            //TODO is there a way to make bevy auto remove these or not panic or something
+            commands.entity(task_entity).despawn_recursive();
+            *connected = result;
+        }
+    }
+}
+
+fn update_connected_components<T: Component>(
+    mut commands: Commands,
+    grid: Res<Grid<T>>,
+    mut events: EventReader<DirtyGridEvent<T>>,
+    // Should maybe be a resource?
+    current_tasks: Query<Entity, With<ConnectedTask<T>>>,
+) {
+    if !events.is_empty() {
+        events.clear();
+        for task in &current_tasks {
+            commands.entity(task).despawn_recursive();
+        }
+
+        let thread_pool = AsyncComputeTaskPool::get();
+        let grid = Box::new(grid.clone());
+
+        let task = thread_pool.spawn(async move {
+            let starts = all_points()
+                .into_iter()
+                .filter(|point| !grid.occupied(point))
+                .collect::<Vec<_>>();
+
+            ConnectedComponents::<T> {
+                components: connected_components::connected_components(&starts, |p| {
+                    neumann_neighbors(&grid, p)
+                }),
+                ..default()
+            }
+        });
+
+        commands.spawn(ConnectedTask { task });
+    }
+}
+
+fn remove_from_grid<T: Component>(
+    mut grid: ResMut<Grid<T>>,
+    mut query: RemovedComponents<T>,
+    mut dirty: EventWriter<DirtyGridEvent<T>>,
+) {
+    for removed_entity in query.iter() {
+        // Search for entity
+        let removed = grid.iter().find(|(entity, _)| *entity == removed_entity);
+        if let Some((_, location)) = removed {
+            dirty.send(DirtyGridEvent::<T>(location.clone(), PhantomData));
+            grid[&location] = None;
+        }
+    }
+}
+
+fn add_to_grid<T: Component>(
+    mut grid: ResMut<Grid<T>>,
+    query: Query<(Entity, &GridLocation), Added<T>>,
+    mut dirty: EventWriter<DirtyGridEvent<T>>,
+) {
+    for (entity, location) in &query {
+        if let Some(existing) = grid[location] {
+            if existing != entity {
+                warn!("Over-writing entity in grid");
+                dirty.send(DirtyGridEvent::<T>(location.clone(), PhantomData));
+                grid[location] = Some(entity);
+            }
+        } else {
+            dirty.send(DirtyGridEvent::<T>(location.clone(), PhantomData));
+            grid[location] = Some(entity);
+        }
+    }
+}
+
+fn all_points() -> Vec<GridLocation> {
+    (0..GRID_SIZE)
+        .flat_map(|x| (0..GRID_SIZE).map(move |y| GridLocation::new(x as u32, y as u32)))
+        .collect()
+}
+
+impl<T> Default for ConnectedComponents<T> {
+    fn default() -> Self {
+        Self {
+            components: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<T> Clone for Grid<T> {
+    fn clone(&self) -> Self {
+        Self {
+            entities: self.entities,
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<T> Default for Grid<T> {
+    fn default() -> Self {
+        Self {
+            entities: [[None; GRID_SIZE]; GRID_SIZE],
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl GridLocation {
+    pub fn new(x: u32, y: u32) -> Self {
+        GridLocation(IVec2::new(x as i32, y as i32))
+    }
+
+    pub fn from_world_position(position: Vec2) -> Option<Self> {
+        let position = position + Vec2::splat(0.5);
+        let location = GridLocation(IVec2::new(position.x as i32, position.y as i32));
+        if Grid::<()>::valid_index(&location) {
+            Some(location)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<IVec2> for GridLocation {
+    fn from(value: IVec2) -> Self {
+        GridLocation(value)
+    }
+}
+
+impl<T> Grid<T> {
+    pub fn occupied(&self, location: &GridLocation) -> bool {
+        Grid::<T>::valid_index(location) && self[location].is_some()
+    }
+
+    pub fn valid_index(location: &GridLocation) -> bool {
+        location.x >= 0
+            && location.y >= 0
+            && location.x < GRID_SIZE as i32
+            && location.y < GRID_SIZE as i32
+    }
+}
+
+impl<T> Grid<T> {
+    pub fn iter(&self) -> impl Iterator<Item = (Entity, GridLocation)> + '_ {
+        self.entities
+            .iter()
+            .flatten()
+            .enumerate()
+            .filter(|(_i, entity)| entity.is_some())
+            .map(|(i, entity)| {
+                (
+                    entity.unwrap(),
+                    GridLocation::new(i as u32 / GRID_SIZE as u32, i as u32 % GRID_SIZE as u32),
+                )
+            })
+    }
+}
+
+impl<T> Index<&GridLocation> for Grid<T> {
+    type Output = Option<Entity>;
+
+    fn index(&self, index: &GridLocation) -> &Self::Output {
+        &self.entities[index.x as usize][index.y as usize]
+    }
+}
+
+impl<T> IndexMut<&GridLocation> for Grid<T> {
+    fn index_mut(&mut self, index: &GridLocation) -> &mut Self::Output {
+        &mut self.entities[index.x as usize][index.y as usize]
+    }
+}
+
+impl<T> ConnectedComponents<T> {
+    pub fn point_to_component(&self, start: &GridLocation) -> Option<&HashSet<GridLocation>> {
+        self.components
+            .iter()
+            .find(|component| component.contains(start))
+    }
+
+    pub fn is_in_same_component(&self, start: &GridLocation, end: &GridLocation) -> bool {
+        self.point_to_component(start) == self.point_to_component(end)
+    }
+
+    pub fn get_random_point_in_same_component<R>(
+        &self,
+        start: &GridLocation,
+        rng: &mut R,
+    ) -> Option<GridLocation>
+    where
+        R: Rng + ?Sized,
+    {
+        self.point_to_component(start)
+            .and_then(|component| component.iter().choose(rng).cloned())
+    }
+}
+
+pub fn neumann_neighbors<T>(grid: &Grid<T>, location: &GridLocation) -> Vec<GridLocation> {
+    let (x, y) = (location.x as u32, location.y as u32);
+
+    let mut sucessors = Vec::new();
+    if let Some(left) = x.checked_sub(1) {
+        let location = GridLocation::new(left, y);
+        if !grid.occupied(&location) {
+            sucessors.push(location);
+        }
+    }
+    if let Some(down) = y.checked_sub(1) {
+        let location = GridLocation::new(x, down);
+        if !grid.occupied(&location) {
+            sucessors.push(location);
+        }
+    }
+    if x + 1 < GRID_SIZE as u32 {
+        let right = x + 1;
+        let location = GridLocation::new(right, y);
+        if !grid.occupied(&location) {
+            sucessors.push(location);
+        }
+    }
+    if y + 1 < GRID_SIZE as u32 {
+        let up = y + 1;
+        let location = GridLocation::new(x, up);
+        if !grid.occupied(&location) {
+            sucessors.push(location);
+        }
+    }
+    sucessors
+}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,8 +1,12 @@
+mod grid;
 mod starfield;
+mod wall;
 
 use starfield::spawn_star_field;
 
 use bevy::prelude::*;
+
+use self::wall::WallPlugin;
 
 // === Plugin ===
 pub struct GamePlugin;
@@ -10,6 +14,8 @@ pub struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app
+            //Plugins
+            .add_plugins(WallPlugin)
             // Systems
             .add_systems(Startup, spawn_camera)
             .add_systems(Startup, spawn_star_field);

--- a/src/game/wall.rs
+++ b/src/game/wall.rs
@@ -1,0 +1,37 @@
+pub use bevy::prelude::*;
+
+use super::grid::{GridLocation, GridPlugin, GRID_SIZE};
+
+#[derive(Component, Default)]
+pub struct Wall;
+
+pub struct WallPlugin;
+
+impl Plugin for WallPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(GridPlugin::<Wall>::default())
+            .add_systems(Startup, spawn_test_walls);
+    }
+}
+
+fn spawn_test_walls(mut commands: Commands) {
+    for i in 0..GRID_SIZE {
+        spawn_test_wall(&mut commands, i, 0);
+        spawn_test_wall(&mut commands, i, GRID_SIZE - 1);
+    }
+    for j in 1..GRID_SIZE - 1 {
+        spawn_test_wall(&mut commands, 0, j);
+        spawn_test_wall(&mut commands, GRID_SIZE - 1, j);
+    }
+}
+
+fn spawn_test_wall(commands: &mut Commands, x: usize, y: usize) {
+    commands.spawn((
+        SpriteBundle {
+            transform: Transform::from_xyz(x as f32, y as f32, 0.0),
+            ..default()
+        },
+        Wall,
+        GridLocation::new(x as u32, y as u32),
+    ));
+}


### PR DESCRIPTION
This adds the grid plugin and a basic wall plugin to showcase the behavior.

Basically all you need to do to use it is add a version of the grid plugin that is generic over the component you want to track (i.e. Wall) and the grid should handle most things (I have some TODOs about objects moving around).

Entities will automatically be added and removed from the grid if they have both the tracking component and the GridLocation component.

The grid also has some connected component tools for things like rooms and power spreading on wires.  Currently this is inverted (the components are everywhere not occupied on the grid, this worked better for path-finding but is counter-intuitive) but I think it would make sense to swap this around.

In my original project I had the world coordinates correspond to the grid location so for the current demo that is the same and the walls are each 1 pixel wide.  We need to decide on how we want the camera setup but I personally like the solution of 1 world unit being one grid unit and the camera scaling being based around that.

TODO: 
Better grid docs :)
Dead code warnings